### PR TITLE
docs: update README and privacy policy

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -4,87 +4,89 @@
 
 ## Overview
 
-TidyTabs ("the Extension") is a Chrome browser extension that helps users organize their browser tabs using AI-powered categorization. We are committed to protecting your privacy and being transparent about our data practices.
+TidyTabs (the Extension) is a Chrome browser extension that helps users organize their browser tabs using AI-powered categorization. We are committed to protecting your privacy and being transparent about our data practices.
 
 ## Information We Collect
 
 ### Tab Information
 
-- **What we collect**: Tab URLs and titles from your browser
-- **How we use it**: To categorize and organize your tabs into groups
-- **Storage**: This information is processed temporarily and is not permanently stored
+- What we access: Tab URLs and titles from your browser
+- How we use it: To categorize and organize your tabs into groups
+- Storage: Processed temporarily for organization. Any associated settings or cached categorization metadata are stored locally in your browser
+- Location: All data is stored locally in your browser (chrome.storage.local)
 
 ### API Keys
 
-- **What we collect**: Your OpenAI and/or Anthropic API keys (if provided)
-- **How we use it**: To authenticate requests to AI services for tab categorization
-- **Storage**: Stored locally in your browser using Chrome's storage API with base64 obfuscation
+- What we access: Your OpenAI and/or Anthropic API keys if you choose to provide them
+- Groq Free Tier: Does not require you to provide an API key to use Category mode by default
+- How we use keys: To authenticate requests to the selected AI service solely for tab categorization
+- Storage: If provided, keys are stored locally in your browser using Chrome’s storage API with base64 obfuscation (note: not encryption)
 
-### Usage Data
+### Usage Data for Local Features
 
-- **What we collect**: Tab access frequency and patterns
-- **How we use it**: For the Frequency organization algorithm
-- **Storage**: Stored locally in your browser
+- What we store: Tab access frequency and patterns (for the Frequency algorithm)
+- How we use it: Improves local, offline organization (e.g., Most Used, Frequently Accessed)
+- Storage: Stored locally in your browser
 
 ## How We Use Information
 
-1. **Tab Organization**: We analyze tab URLs and titles to categorize them into meaningful groups
-2. **AI Processing**: When using the Category algorithm, tab information is sent to your selected AI provider (OpenAI or Anthropic)
-3. **Local Processing**: Last Access and Frequency algorithms process data entirely locally
+1. Tab Organization: We analyze tab URLs and titles to assign them to meaningful groups
+2. AI Processing: When you use the Category (AI) algorithm, tab titles and URLs are sent to your selected AI provider (Groq, OpenAI, or Anthropic) to obtain a category result
+3. Local Processing: Last Access and Frequency algorithms process data entirely on your device without transmitting tab data to external services
 
 ## Third-Party Services
 
-When you use the AI-powered Category algorithm, tab URLs and titles are sent to:
+When you use the AI-powered Category algorithm, tab titles and URLs are sent to your selected provider:
 
-- **OpenAI** (if selected): Subject to [OpenAI's Privacy Policy](https://openai.com/privacy/)
-- **Anthropic** (if selected): Subject to [Anthropic's Privacy Policy](https://www.anthropic.com/privacy)
+- Groq (if selected; Groq Free Tier is the default)
+- OpenAI (if selected and you provide an API key)
+- Anthropic (if selected and you provide an API key)
 
-**Important**: These services process the data according to their own privacy policies. We recommend reviewing their policies before use.
+These services process the data according to their own privacy policies and terms. Please review the selected provider’s policies before use.
 
 ## Data Storage
 
-- All data is stored locally on your device using Chrome's storage API
-- No data is sent to our servers (we don't have any)
-- API keys are obfuscated but not encrypted (use at your own risk)
+- All settings, cached categorizations, and usage data are stored locally on your device using Chrome’s storage API
+- No data is sent to any developer-controlled servers (we do not operate any servers for this Extension)
+- API keys (if provided) are stored locally with base64 obfuscation (not encryption)
 
 ## Data Sharing
 
 We DO NOT:
-
 - Sell your data to third parties
 - Share your data with advertisers
 - Track you across websites
 - Store your browsing history on external servers
+- Collect analytics or telemetry about your usage of the Extension
 
-## Your Rights
+Data is only transmitted to the AI provider you explicitly choose when you run the Category (AI) algorithm.
+
+## Your Choices and Controls
 
 You can:
-
-- **Delete all data**: Clear Chrome extension storage through Chrome settings
-- **Disable the extension**: Turn off or uninstall TidyTabs at any time
-- **Use without AI**: Use Last Access or Frequency algorithms that work entirely offline
-- **Control API usage**: Choose which AI provider to use or none at all
+- Delete all data: Clear Chrome extension storage from Chrome settings
+- Disable the extension: Turn off or uninstall TidyTabs at any time
+- Use without AI: Select Last Access or Frequency algorithms that work entirely offline
+- Control AI usage: Choose which AI provider to use (Groq, OpenAI, Anthropic) or none at all
 
 ## Security
 
-- API keys are stored with base64 obfuscation (not true encryption)
 - All AI API communications use HTTPS
-- No data is transmitted except to your chosen AI provider
+- No data is transmitted except to your selected AI provider to obtain a category result
+- API keys saved in the Extension are obfuscated in local storage (not encryption). Do not share your device or browser profile with untrusted parties
 
-## Children's Privacy
+## Children’s Privacy
 
 This Extension is not intended for use by children under 13 years of age.
 
 ## Changes to This Policy
 
-We may update this privacy policy from time to time. Check the "Effective Date" at the top for the latest version.
+We may update this privacy policy from time to time. Check the Effective Date at the top for the latest version.
 
 ## Contact
 
 For questions about this privacy policy or the Extension:
-
 - Create an issue on our GitHub repository
-- Email: [Your contact email here]
 
 ## Consent
 
@@ -92,4 +94,7 @@ By using TidyTabs, you consent to this privacy policy and agree to its terms.
 
 ---
 
-**Remember**: Your tab data is only sent to AI providers when you explicitly use the Category organization feature with a configured API key. All other features work entirely offline.
+Important:
+- Tab titles and URLs are only sent to an AI provider when you explicitly use the Category (AI) algorithm
+- Groq Free Tier does not require you to provide an API key, but requests will still be sent to Groq when you trigger Category mode
+- Last Access and Frequency algorithms run entirely on your device and do not send tab data to any external service

--- a/README.md
+++ b/README.md
@@ -1,0 +1,161 @@
+# TidyTabs — Chrome Extension
+
+AI-powered Chrome extension that intelligently organizes your tabs by:
+- Category (LLM/AI using your custom categories)
+- Last Access (time-based buckets)
+- Frequency (usage patterns with recency weighting)
+
+Modern UI with a design system, glassmorphism touches, and light/dark/auto themes. Built on Manifest V3 with a service worker.
+
+## Highlights
+
+- Organize tabs on-demand from the popup or automatically via Auto Mode
+- Three organization methods
+  - Category: AI-powered grouping with your custom categories
+  - Last Access: Groups like Just Now, Recent, Earlier Today, Yesterday, This Week, Older
+  - Frequency: Most Used, Frequently Accessed, Occasionally Used, Rarely Used
+- Groq Free Tier by default (no API key required). Optional OpenAI or Anthropic for your own keys
+- AI-first policy: Only uses your defined categories. If AI cannot confidently match, tabs go to Uncategorized
+- Duplicate group prevention and category consolidation
+- Beautiful design system, smooth micro-interactions, dark/light/auto themes
+- Privacy-focused: data stored locally in your browser; only AI API calls are made when you use Category mode
+
+## Current Status
+
+- Production-ready with real AI provider integrations:
+  - Groq Free Tier (default, no setup required)
+  - OpenAI (bring your own key; default model: gpt-5-mini)
+  - Anthropic (bring your own key; default model: claude-sonnet-4-20250514)
+- Smart batching, rate limiting, error handling, and confidence-based caching
+- Options page supports provider selection, API keys, custom categories, theme, defaults
+- Popup provides quick organize, algorithm switching, and Auto Mode toggle
+- Icons ready for Chrome Web Store listing
+
+For full details, see:
+- Providers and prompts: [src/llm/LLMProvider.js](src/llm/LLMProvider.js:1), [src/llm/PromptTemplates.js](src/llm/PromptTemplates.js:1)
+- Algorithms: [src/algorithms/CategoryAlgorithm.js](src/algorithms/CategoryAlgorithm.js:1), [src/algorithms/LastAccessAlgorithm.js](src/algorithms/LastAccessAlgorithm.js:1), [src/algorithms/FrequencyAlgorithm.js](src/algorithms/FrequencyAlgorithm.js:1)
+- Settings and groups: [src/core/SettingsManager.js](src/core/SettingsManager.js:1), [src/core/TabGroupManager.js](src/core/TabGroupManager.js:1), [src/core/TabOrganizer.js](src/core/TabOrganizer.js:1)
+
+## Installation
+
+Load Unpacked (development):
+1. Open Chrome and navigate to chrome://extensions
+2. Enable Developer mode
+3. Click Load unpacked
+4. Select this project folder
+
+Install from Chrome Web Store (coming soon)
+
+## Usage
+
+1. Click the TidyTabs toolbar icon to open the popup
+2. Choose the organization algorithm:
+   - Category (AI)
+   - Last Access
+   - Frequency
+3. Click Organize Tabs Now
+
+Auto Mode:
+- Toggle on to automatically organize when new tabs are created or updated (with sensible debouncing)
+
+Ungroup before recategorize (optional):
+- In the popup, you can enable Ungroup all tabs first before recategorizing
+- When enabled, all existing groups are cleared before AI recategorization for a completely fresh result
+- The toggle state persists in Chrome storage
+
+## Custom Categories
+
+Define your categories in Options:
+- Add up to 24 categories with names, colors, and optional icons
+- Drag and drop to reorder; AI prioritizes higher-ranked categories
+- Validation: Names 2–30 characters, alphanumeric with spaces/hyphens
+- Colors: 9 Chrome group colors (grey, blue, red, yellow, green, pink, purple, cyan, orange)
+- When a category is deleted, TidyTabs will recategorize affected tabs
+
+Implementation references:
+- [src/core/CustomCategoryManager.js](src/core/CustomCategoryManager.js:1)
+- [src/constants/categories.js](src/constants/categories.js:1)
+
+## AI Providers
+
+Default: Groq (Free Tier)
+- Works out of the box without an API key
+- Rate limits (typical): 10 requests/min, 100/hour, 500/day
+
+Bring your own key:
+- OpenAI (default model: gpt-5-mini)
+- Anthropic (default model: claude-sonnet-4-20250514)
+
+Behavior:
+- AI strictly uses your custom categories; no invented categories
+- If uncertain, tabs fall back to Uncategorized
+- Confidence-based caching reduces unnecessary re-calls
+- No domain-based fallback (AI-first policy)
+
+Technical references:
+- [src/llm/providers/GroqProvider.js](src/llm/providers/GroqProvider.js:1)
+- [src/llm/providers/OpenAIProvider.js](src/llm/providers/OpenAIProvider.js:1)
+- [src/llm/providers/AnthropicProvider.js](src/llm/providers/AnthropicProvider.js:1)
+
+## Settings
+
+Open the Options page (from the popup, or chrome://extensions → Details → Extension options):
+- AI Provider: Groq (default), OpenAI, or Anthropic
+- Default Algorithm: Category (AI), Last Access, Frequency
+- Auto Mode: On/off with debouncing
+- Theme: Auto, Light, or Dark (applied immediately)
+- Custom Categories: Add/edit/delete/reorder
+- API Keys: Stored locally with base64 obfuscation
+
+## Privacy Summary
+
+- All data is stored locally in your browser using chrome.storage.local
+- No developer servers are used; TidyTabs does not collect analytics or telemetry
+- When you use the Category algorithm, TidyTabs sends tab titles and URLs to your selected AI provider (Groq, OpenAI, or Anthropic) over HTTPS to obtain categories
+- API keys you provide are stored locally with base64 obfuscation and are used only to authenticate calls to the selected provider
+
+Read the full policy: [PRIVACY_POLICY.md](PRIVACY_POLICY.md)
+
+## Development
+
+Install dev tools locally (optional):
+- ESLint and Prettier are provided for formatting and linting
+
+Scripts:
+- npm run clean — remove dist/ and re-create the folder
+- npm run format — Prettier format all files
+- npm run lint — ESLint check (.js files)
+- npm run zip — package the extension into dist/tidytabs-$VERSION.zip
+- npm run build — clean → format → zip
+
+Build artifacts are generated into dist/.
+
+## Architecture Overview
+
+- Manifest V3 with a service worker coordinating tab events and messaging
+- Popup (action) for manual organization controls
+- Options page for providers, algorithms, auto-mode, theme, API keys
+- Core modules:
+  - Settings Manager: persistence with defaults and validation
+  - Tab Organizer: orchestrates algorithms and creates tab groups
+  - Algorithms: Category (AI), Last Access (time buckets), Frequency (usage)
+  - LLM Provider Layer: normalized interface for providers (Groq, OpenAI, Anthropic)
+  - Utilities: Logger, ThemeManager, Storage wrappers, Tab utilities, UI helpers
+- Design system CSS and components with modern tokens and animations
+
+Key files:
+- Service worker: [src/service-worker/background.js](src/service-worker/background.js:1)
+- Organizer and groups: [src/core/TabOrganizer.js](src/core/TabOrganizer.js:1), [src/core/TabGroupManager.js](src/core/TabGroupManager.js:1)
+- Options UI: [options/options.html](options/options.html:1), [options/options.js](options/options.js:1), [options/options.css](options/options.css:1)
+- Popup UI: [popup/popup.html](popup/popup.html:1), [popup/popup.js](popup/popup.js:1), [popup/popup.css](popup/popup.css:1)
+
+## Roadmap
+
+- Continued prompt optimization and categorization accuracy
+- Additional provider model options in UI
+- More granular controls for batching and debouncing
+- Store listing, screenshots, and release automation
+
+## Support
+
+- Open a GitHub issue for bugs or feature requests


### PR DESCRIPTION
Clarifies local-only storage and that the only external calls are to AI providers (Groq default, optional OpenAI/Anthropic). Removes Manual Overrides per AI-first policy.
Files: [README.md](README.md), [PRIVACY_POLICY.md](PRIVACY_POLICY.md).